### PR TITLE
调整格式以适配 appengine 显示

### DIFF
--- a/content/concurrency.article
+++ b/content/concurrency.article
@@ -166,8 +166,9 @@ _提示_：你可以用一个 map 来缓存已经获取的 URL，但是要注意
 
 #appengine: 你可以从[[https://go-zh.org/doc/install/][安装 Go]] 开始。
 
-#appengine: 一旦安装了 Go，
-[[https://go-zh.org/doc/][Go 文档]]是一个极好的
+#appengine: 一旦安装了 Go，Go
+Go
+[[https://go-zh.org/doc/][文档]]是一个极好的
 #appengine: 应当继续阅读的内容。
 开始。
 它包含了参考、指南、视频等等更多资料。

--- a/content/flowcontrol.article
+++ b/content/flowcontrol.article
@@ -114,7 +114,7 @@ switch 的 case 语句从上到下顺次执行，直到匹配成功时停止。
 
 在 `i==0` 时 `f` 不会被调用。）
 
-#appengine: *注意：* Go 练习场中的时间总是从 2009-11-10 23:00:00 UTC 开始，该值的意义就作为留给读者去发现。
+#appengine: *注意：* Go 练习场中的时间总是从 2009-11-10 23:00:00 UTC 开始，该值的意义留给读者去发现。
 
 .play flowcontrol/switch-evaluation-order.go
 

--- a/content/welcome.article
+++ b/content/welcome.article
@@ -60,53 +60,48 @@ https://go-zh.org
 点击[[javascript:highlightAndClick(".next-page")][“下一页”]]按钮或者按 `PageDown` 键继续。
 
 #appengine: * Go 离线版
-#appengine:
+#appengine: 
 #appengine: 本指南也可作为独立的程序使用，这样你无需访问互联网就能运行它。
-#appengine:
+#appengine: 
 #appengine: 独立版的指南更快，因为它会在你的机器上构建并运行代码示例。
-#appengine:
+#appengine: 
 #appengine: 要在本地运行此教程的中文版，首先请[[https://golang.org/dl/][下载并安装 Go]]，
-#appengine: 然后用[[https://go-zh.org/cmd/go/][go get]]命令来安装
+#appengine: 然后用 [[https://go-zh.org/cmd/go/][go get]] 命令来安装
 #appengine: [[https://go-zh.org/x/tour/][gotour]]:
-#appengine:
+#appengine: 
 #appengine: 	go get github.com/Go-zh/tour/gotour
-#appengine:
+#appengine: 
 #appengine: 最后运行产生的 `gotour` 可执行文件。
-#appengine:
-#appengine: 如果要运行本教程的英文版，首先请
-#appengine: [[https://golang.org/dl/][下载并安装 Go]]，
-#appengine: 接着从命令行启动教程：
-#appengine:
+#appengine: 
+#appengine: 如果要运行本教程的英文版，首先请[[https://golang.org/dl/][下载并安装 Go]]，接着从命令行启动教程：
+#appengine: 
 #appengine: 	go tool tour
-#appengine:
-#appengine: 如果上面的方式遇到了问题，并且你能够直接访问 Google 的服务器，
-#appengine: 那么你也可以手动安装并运行本教程：
-#appengine:
-#appengine:		go get golang.org/x/tour/gotour
-#appengine:		gotour
-#appengine:
+#appengine: 
+#appengine: 如果上面的方式遇到了问题，并且你能够直接访问 Google 的服务器，那么你也可以手动安装并运行本教程：
+#appengine: 
+#appengine: 	go get golang.org/x/tour/gotour
+#appengine: 	gotour
+#appengine: 
 #appengine: 该程序会打开 Web 浏览器来显示本教程的本地英文版。
-#appengine:
+#appengine: 
 #appengine: 当然，你也可以继续在线学习本教程。
 
 #appengine: * Go 练习场
-#appengine:
-#appengine: 本指南构建在[[https://play.golang.org/][Go 练习场]]上，它是一个运行在
-#appengine: [[https://golang.org/][golang.org]] 服务器上的一个 Web 服务。
-#appengine:
-#appengine: 该服务会接收一个 Go 程序，然后在沙盒中编译、链接并运行它，
-#appengine: 最后返回输出。
-#appengine:
+#appengine: 
+#appengine: 本指南构建在 [[https://play.golang.org/][Go 练习场]]上，它是一个运行在 [[https://golang.org/][golang.org]] 服务器上的一个 Web 服务。
+#appengine: 
+#appengine: 该服务会接收一个 Go 程序，然后在沙盒中编译、链接并运行它，最后返回输出。
+#appengine: 
 #appengine: 在练习场中运行的程序有一些限制：
-#appengine:
+#appengine: 
 #appengine: - 练习场中的时间始于 2009-11-10 23:00:00 UTC（这个日期的含义留给读者去发现）。赋予程序确定的输出能让缓存程序更加容易。
-#appengine:
+#appengine: 
 #appengine: - 程序的执行时间、CPU 和内存的使用同样也有限制，并且程序不能访问外部网络中的主机。
-#appengine:
+#appengine: 
 #appengine: 练习场使用最新发布的 Go 的稳定版本。
-#appengine:
-#appengine: 参阅“[[https://blog.go-zh.org/playground][Go 练习场的内部机制（英文）]]”了解更多信息。
-#appengine:
+#appengine: 
+#appengine: 参阅 [[https://blog.go-zh.org/playground][Go 练习场的内部机制（英文）]]了解更多信息。
+#appengine: 
 #appengine: .play welcome/sandbox.go
 
 * 恭喜！


### PR DESCRIPTION
appengine 版本渲染时需要行尾空白，故保留，以下为修正内容

* 欢迎
    * Go 离线版: 换行，空白等格式修正
    * Go 练习场: 换行，空白等格式修正
* 基础
    * switch 的求值顺序: 提示语与前文保持一致
* 并发
    * 接下来去哪: fixes #299