### PR TITLE
添加映射的英文对照以防止误解

### DIFF
--- a/content/moretypes.article
+++ b/content/moretypes.article
@@ -234,7 +234,7 @@ nil 切片的长度和容量为 0 且没有底层数组。
 
 .play moretypes/exercise-slices.go
 
-* 映射
+* 映射 (`map`)
 
 映射将键映射到值。
 


### PR DESCRIPTION
在映射的描述页， https://tour.go-zh.org/moretypes/19，内容过于简单，为防止误解映射在Go中的含义。特添加英文对照